### PR TITLE
[CS-690] Turn elastic search start and complete into debug logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-elasticsearch-client",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A configuration driven elasticsearch client",
   "main": "build/index.js",
   "scripts": {

--- a/src/apiProxy.js
+++ b/src/apiProxy.js
@@ -42,10 +42,10 @@ export default function getApiProxy(client, req, operationName) {
               operationName: operationName || name,
             };
             client.emit('start', callInfo);
-            log(req, client, 'info', 'elasticsearch start', logInfo);
+            log(req, client, 'debug', 'elasticsearch start', logInfo);
             rz.then((resolved) => {
               callInfo.result = resolved;
-              log(req, client, 'info', 'elasticsearch complete', logInfo);
+              log(req, client, 'debug', 'elasticsearch complete', logInfo);
               client.emit('finish', callInfo);
               return resolved;
             }).catch((error) => {

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,7 +1,7 @@
-box: node
+box: node:8
 
 services:
-  - postgres:9.5-alpine
+  - elasticsearch:5.2.1
 
 build:
   steps:
@@ -10,15 +10,7 @@ build:
     - script:
       name: lint
       code: npm run lint
-
-    - script:
-      name: environment vars
-      code: |
-        export PGHOST=$POSTGRES_PORT_5432_TCP_ADDR
-        export PGPORT=$POSTGRES_PORT_5432_TCP_PORT
-        export PGUSER=postgres
-        export PGPASSWORD=postgres
-
+    
     - npm-test
 
     - script:

--- a/wercker.yml
+++ b/wercker.yml
@@ -10,6 +10,12 @@ build:
     - script:
       name: lint
       code: npm run lint
+
+    - script:
+      name: Setup elasticsearch
+      code: |
+        export ELASTIC_HOST=$ELASTICSEARCH_PORT_9200_TCP_ADDR:$ELASTICSEARCH_PORT_9200_TCP_PORT
+        export ELASTIC_URL=http://$ELASTICHOST
     
     - npm-test
 


### PR DESCRIPTION
Changing elastic search start and complete from info to debug logs.  Also attempting to get this working in wercker.

This is the attempt to silence the production logs a little bit on each elastic search call.