### PR TITLE
Don't re-throw the error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-elasticsearch-client",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-elasticsearch-client",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "A configuration driven elasticsearch client",
   "main": "build/index.js",
   "scripts": {

--- a/src/apiProxy.js
+++ b/src/apiProxy.js
@@ -43,7 +43,6 @@ export function getApiProxy(client, req, operationName) {
               callInfo.result = resolved;
               log(req, client, 'debug', 'elasticsearch complete', logInfo);
               client.emit('finish', callInfo);
-              return resolved;
             }).catch((error) => {
               callInfo.error = error;
               logInfo.error = error;

--- a/src/apiProxy.js
+++ b/src/apiProxy.js
@@ -49,7 +49,6 @@ export function getApiProxy(client, req, operationName) {
               logInfo.error = error;
               log(req, client, 'error', 'elasticsearch failed', logInfo);
               client.emit('error', callInfo);
-              throw error;
             });
           }
 


### PR DESCRIPTION
When the error is re-thrown we are no longer able to handle the error.  In tests, the error ends up going to the rejected promises event.  

Example usage is here:
https://github.com/gas-buddy/poi-serv/blob/f0e625a61ba6381b2669f26b59174e6a57641ebb/src/lib/poi/station.js#L185

When an error is encountered like a 404, the catch block will be hit whether the error is re-thrown or not.  However the re-throw ends up as a rejected promise.

I'm think because this already returning a promise that the re-throw isn't needed.

